### PR TITLE
Remove expired MIDUCONF discount message and code

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -35,13 +35,13 @@ import YellowBackground from "@components/YellowBackground.astro"
         </div>
         <div class="flex flex-col gap-2">
           <div>
-            <tito-button event="js-conf/js-conf-2025" discount-code="MIDUCONF">
+            <tito-button event="js-conf/js-conf-2025" /*discount-code="MIDUCONF"*/>
             <button class="bg-white border-4 border-black text-black font-bold text-xl px-8 py-3 rounded-full hover:bg-opacity-90 duration-300 hover:scale-110 transition uppercase inline-block">
                 ¡Consigue tu entrada!
             </button>
             </tito-button>
           </div>
-        <small>¡Sólo por hoy! Usa cupón "MIDUCONF" para descuento especial</small>
+       <!-- <small>¡Sólo por hoy! Usa cupón "MIDUCONF" para descuento especial</small> -->
       </div>
       </main>
     


### PR DESCRIPTION
### Description
-----
This PR removes the message "¡Sólo por hoy! Usa cupón 'MIDUCONF' para descuento especial" and also eliminates the discount in `tito.js` as it has expired and is no longer valid.