### PR TITLE
Adding GitHub links of the speakers

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -106,7 +106,7 @@ import YellowBackground from "@components/YellowBackground.astro"
                               </a>
                           </li>
                           <li>
-                              <a href="#" class="text-gray-500 hover:hover:text-white">
+                              <a href="https://github.com/javivelasco" class="text-gray-500 hover:hover:text-white">
                                 <svg
                                 class="w-6 h-6"
                                 viewBox="0 0 256 250"
@@ -143,7 +143,7 @@ import YellowBackground from "@components/YellowBackground.astro"
                               </a>
                           </li>
                           <li>
-                              <a href="#" class="text-gray-500 hover:hover:text-white">
+                              <a href="https://github.com/carmenansio" class="text-gray-500 hover:hover:text-white">
                                 <svg
                                 class="w-6 h-6"
                                 viewBox="0 0 256 250"


### PR DESCRIPTION
I have added the links to the GitHub profiles of the speakers since there was only a “#” as url.