### PR TITLE
Fix text center and link hover feedback

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -85,7 +85,7 @@ import YellowBackground from "@components/YellowBackground.astro"
         <div class="py-8 px-4 mx-auto max-w-screen-xl lg:py-16 lg:px-6">
           <div class="mx-auto max-w-screen-sm text-center mb-8 lg:mb-16">
             <h2 class="text-4xl font-bold text-center text-black md:text-6xl">¡Speakers!</h2>
-            <p class="max-w-xl text-2xl text-black/80 text-center [text-wrap:balance] mt-4">¡Aprende del mejor talento de la comunidad hispana!</p>
+            <p class="max-w-full text-2xl text-black/80 text-center [text-wrap:balance] mt-4">¡Aprende del mejor talento de la comunidad hispana!</p>
           </div> 
           <div class="grid gap-6 sm:grid-cols-1 lg:grid-cols-2 xl:grid-cols-3">
               <article class="bg-slate-950 text-white rounded-sm ">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -93,7 +93,7 @@ import YellowBackground from "@components/YellowBackground.astro"
                       <img class="p-4 w-full rounded-lg" src="/javi-velasco.jpeg" alt="Javi Velasco">
                   </a>
                   <div class="px-5 pb-5">
-                      <h3 class="text-2xl font-bold tracking-tight text-white">
+                      <h3 class="text-2xl font-bold tracking-tight text-white hover:underline">
                           <a href="https://x.com/javivelasco">Javier Velasco</a>
                       </h3>
                       <span class="text-yellow-300">Tech Lead @vercel</span>
@@ -130,7 +130,7 @@ import YellowBackground from "@components/YellowBackground.astro"
                       <img class="p-4 w-full rounded-lg" src="/carmen-ansio.webp" alt="Carmen Ansio">
                   </a>
                   <div class="px-5 pb-5">
-                      <h3 class="text-2xl font-bold tracking-tight text-white">
+                      <h3 class="text-2xl font-bold tracking-tight text-white hover:underline">
                           <a href="https://x.com/carmenansio">Carmen Ansio</a>
                       </h3>
                       <span class="text-yellow-300">Design Engineer @LottieFiles</span>


### PR DESCRIPTION
1. The text alignment in the Speakers section was fixed:

Before:
![image](https://github.com/user-attachments/assets/a0d77e40-6509-4175-9059-3a2a06776290)

After:
![image](https://github.com/user-attachments/assets/77055c2a-9ba7-4329-9d98-06ec24de67a2)

2. The names of both speakers now show feedback (underline) when hover:

Before:
![image](https://github.com/user-attachments/assets/87c49796-a05f-4e35-a632-c867146bcb25)

After:
![image](https://github.com/user-attachments/assets/593d3920-272c-4cd3-8afc-35d05759a1b1)
