### PR TITLE
Fix sponsor link and accessibility issues

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -68,8 +68,9 @@ import YellowBackground from "@components/YellowBackground.astro"
         <h2 class="text-4xl font-bold text-center text-white md:text-6xl">Patrocinadores</h2>
         <p class="max-w-xl text-2xl text-white/80 text-center [text-wrap:balance] mt-4">¡Gracias a ellos hacemos posible el evento!</p>
         <div class="relative flex flex-col items-center justify-center w-full h-full gap-4 py-20 overflow-hidden rounded-lg max-w-screen-base bg-background">
-          <a href='https://midu.link/keepcoding' class="hover:scale-105 transition" target="_blank" rel="noopener"></a>
-          <img src="/keepcoding.webp" alt="KeepCoding" class="w-full h-full object-cover max-w-2xl mx-auto">
+          <a href='https://midu.link/keepcoding' class="hover:scale-105 transition" target="_blank" rel="noopener">
+            <img src="/keepcoding.webp" alt="KeepCoding" class="w-full h-full object-cover max-w-2xl mx-auto">
+          </a>
           <span class="text-base opacity-70">Los mejores bootcamps online</span>
         </div>
         <a href="mailto:miduga@gmail.com" target="_blank" class="bg-white border-4 border-black text-black font-bold text-xl px-8 py-3 rounded-full hover:bg-opacity-90 duration-300 hover:scale-110 transition uppercase inline-block">
@@ -101,12 +102,12 @@ import YellowBackground from "@components/YellowBackground.astro"
                       <ul class="flex space-x-4 sm:mt-0 items-center">
                           
                           <li>
-                              <a href="https://x.com/javivelasco" class="text-gray-500 hover:hover:text-white">
+                              <a href="https://x.com/javivelasco" class="text-gray-500 hover:hover:text-white" aria-label="X (Twitter)">
                                 <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" width="1200" height="1227" fill="none" viewBox="0 0 1200 1227"><path fill="currentColor" d="M714.163 519.284 1160.89 0h-105.86L667.137 450.887 357.328 0H0l468.492 681.821L0 1226.37h105.866l409.625-476.152 327.181 476.152H1200L714.137 519.284h.026ZM569.165 687.828l-47.468-67.894-377.686-540.24h162.604l304.797 435.991 47.468 67.894 396.2 566.721H892.476L569.165 687.854v-.026Z"/></svg>
                               </a>
                           </li>
                           <li>
-                              <a href="#" class="text-gray-500 hover:hover:text-white">
+                              <a href="#" class="text-gray-500 hover:hover:text-white" aria-label="Github">
                                 <svg
                                 class="w-6 h-6"
                                 viewBox="0 0 256 250"
@@ -138,12 +139,12 @@ import YellowBackground from "@components/YellowBackground.astro"
                       <ul class="flex space-x-4 sm:mt-0 items-center">
                           
                           <li>
-                              <a href="https://x.com/carmenansio" class="text-gray-500 hover:hover:text-white">
+                              <a href="https://x.com/carmenansio" class="text-gray-500 hover:hover:text-white" aria-label="X (Twitter)">
                                 <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" width="1200" height="1227" fill="none" viewBox="0 0 1200 1227"><path fill="currentColor" d="M714.163 519.284 1160.89 0h-105.86L667.137 450.887 357.328 0H0l468.492 681.821L0 1226.37h105.866l409.625-476.152 327.181 476.152H1200L714.137 519.284h.026ZM569.165 687.828l-47.468-67.894-377.686-540.24h162.604l304.797 435.991 47.468 67.894 396.2 566.721H892.476L569.165 687.854v-.026Z"/></svg>
                               </a>
                           </li>
                           <li>
-                              <a href="#" class="text-gray-500 hover:hover:text-white">
+                              <a href="#" class="text-gray-500 hover:hover:text-white" aria-label="Github">
                                 <svg
                                 class="w-6 h-6"
                                 viewBox="0 0 256 250"


### PR DESCRIPTION
1. The KeepCoding link now works properly.
2. All accessibility issues were fixed.
![Accessibility](https://github.com/user-attachments/assets/d9603674-3465-4417-a22e-deb49efd81af)

> **Note: Only the `href` attributes are missing. I didn't add those because #5 fixes it.**