### PR TITLE
Feature/add radial gradient background

### DIFF
--- a/src/sections/PreEvent.astro
+++ b/src/sections/PreEvent.astro
@@ -8,7 +8,7 @@ import InfojobsLogo from '@/icons/InfojobsLogo.svg'
 
 <section class="bg-black text-black flex flex-col px-0">
   <Container>
-    <div class="bg-javascript pt-6 xl:pt-12 pb-4 px-6 xl:px-12">
+    <div class="bg-javascript-radial pt-6 xl:pt-12 pb-4 px-6 xl:px-12">
       <div class="flex items-start justify-between flex-col xl:flex-row gap-3 xl:gap-24">
         <div class="flex flex-col flex-1 gap-4 text-balance font-clash pt-6">
           <h3 class="text-6xl font-medium">Únete al Pre-Evento en Barcelona</h3>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -10,6 +10,9 @@ export default {
         clash: ['Clash', 'system-ui', 'sans-serif'],
         inter: ['Inter', 'system-ui', 'sans-serif'],
       },
+      backgroundImage: {
+        'javascript-radial': 'radial-gradient(ellipse farthest-corner at 0% 0%, #FFFE65, #F7DF1F)',
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
- Add a custom radial gradient in tailwind.config.mjs according to the colors from the Figma design. 
- Use the radial gradient for the background of the PreEvent section.

Before: 
![image](https://github.com/user-attachments/assets/048296d3-4b28-4146-8c2d-f4237a1c8068)


After: 
![image](https://github.com/user-attachments/assets/0e2ca649-cf65-46ea-9a63-1fa8fce79b21)

Figma: 
![image](https://github.com/user-attachments/assets/4d56ee5c-fe50-4cb2-a567-522d01257059)


