### PR TITLE
style: Hide SVG on smaller screens for improved responsiveness

### DIFF
--- a/src/sections/Why.astro
+++ b/src/sections/Why.astro
@@ -11,6 +11,7 @@ import WhyCard from '@/components/WhyCard.astro'
       height="1123"
       viewBox="0 0 770 1123"
       fill="none"
+      class="hidden md:block"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path


### PR DESCRIPTION
En pantallas pequeñas el svg forzaba que la anchura fuese más grande
![image](https://github.com/user-attachments/assets/aad578b5-bbc9-4bef-b8d3-fde21d258b27)

Solucionado ocultando el svg en pantallas pequeñas