### PR TITLE
geekhadev - fix: enhance z-index for overlapping elements in Why section

### DIFF
--- a/src/sections/Why.astro
+++ b/src/sections/Why.astro
@@ -7,7 +7,7 @@ import Ticket from '@/icons/Ticket.svg'
 ---
 
 <section class="bg-black text-white md:max-w-5/6 mx-auto px-4 py-12">
-  <div class="absolute">
+  <div class="absolute z-10">
     <svg
       width="770"
       height="1123"
@@ -38,7 +38,7 @@ import Ticket from '@/icons/Ticket.svg'
     </svg>
   </div>
 
-  <Container>
+  <Container class="relative z-20">
     <h2
       class="md:text-6xl text-4xl md:w-5/6 max-md:text-center font-medium font-clash md:ml-0 md:mr-auto mb-12"
     >


### PR DESCRIPTION
Se ha corregido un problema de superposición en la sección "Why" donde un `div` con posición `absolute` esta cubriendo otros elementos, incluyendo (dependiendo de la resolución) el botón "¡Consigue tu entrada!". Para solucionar esto, se ha ajustado el `z-index` del `div` y del contenedor principal. Ahora, el `div` con el SVG tiene un `z-index` menor, asegurando que los elementos importantes, como el botón, se muestren correctamente por encima.

![Screenshot 2024-12-12 at 11 21 17 PM](https://github.com/user-attachments/assets/040c33fe-255b-4432-bd5c-a48a39355f56)
![Screenshot 2024-12-12 at 11 21 53 PM](https://github.com/user-attachments/assets/1913b180-1ca2-476f-a8b3-f92aa41bf5ab)
