### PR TITLE
style: Fix underline responsive

### DIFF
--- a/src/components/UnderlineWord.astro
+++ b/src/components/UnderlineWord.astro
@@ -2,7 +2,7 @@
 const { class: className } = Astro.props
 ---
 
-<span class="relative">
+<span class="relative inline-block">
   <slot />
   <span class:list={['absolute -bottom-4 left-0 right-0', className]}>
     <svg

--- a/src/sections/Presenter.astro
+++ b/src/sections/Presenter.astro
@@ -18,7 +18,7 @@ import UnderlineWord from '@/components/UnderlineWord.astro'
       />
       <div class="md:w-7/12 flex flex-col md:p-10 md:gap-y-10 gap-y-8">
         <h2 class="md:text-5xl text-[34px] font-clash font-medium">
-          Presentado por <UnderlineWord class="text-white"
+          Presentado por <UnderlineWord class="text-white !-translate-x-5 !-translate-y-2 md:!translate-x-0 md:!translate-y-0"
             ><span class="text-javascript">midudev</span></UnderlineWord
           >
         </h2>

--- a/src/sections/WhenAndWhere.astro
+++ b/src/sections/WhenAndWhere.astro
@@ -12,7 +12,7 @@ import ArrowRight from '@/icons/ArrowRight.svg'
   <Container>
     <h2 class="text-6xl text-center font-clash max-w-5xl mx-auto">
       El día que Madrid se convertirá en la <strong class="font-semibold"
-        >capital española de <UnderlineWord class="translate-x-1/4">JavaScript</UnderlineWord>
+        >capital española de <UnderlineWord class="!left-20">JavaScript</UnderlineWord>
       </strong>
     </h2>
 


### PR DESCRIPTION
Arreglo en la posicion del underline en la vista mobile, antes los underline salian del marco con el cambio de posicion en las letras que tienen el underline y hacia que se viera un marco a la derecha de la web

Antes:
![imagen](https://github.com/user-attachments/assets/08f28231-73ed-4e58-9978-07fa8e8b7b46)
![imagen](https://github.com/user-attachments/assets/5eef59f8-695c-4968-a568-9f14e0f32f4a)
![imagen](https://github.com/user-attachments/assets/1fe92590-a271-4349-8440-d1dbb5942f1c)

Despues:
![imagen](https://github.com/user-attachments/assets/0c1fad9f-a39f-4e8a-981e-b5b5e0c8002b)
![imagen](https://github.com/user-attachments/assets/951cd3d6-fff2-472d-bb24-aadaf0b3a7af)
![imagen](https://github.com/user-attachments/assets/0f44d1f0-4a5a-4f3c-a397-1bd278d4e924)