### PR TITLE
feat: add ICS file to support all calendar managers

### DIFF
--- a/public/jsconfes.ics
+++ b/public/jsconfes.ics
@@ -1,0 +1,36 @@
+BEGIN:VCALENDAR
+VERSION:2.0
+CALSCALE:GREGORIAN
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:DAYLIGHT
+TZNAME:CEST
+TZOFFSETFROM:+0100
+TZOFFSETTO:+0200
+DTSTART:19700329T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZNAME:CET
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+DTSTART:19701025T030000
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+DTSTAMP:20241214T173526Z
+UID:1734197641130-77568
+DTSTART;VALUE=DATE:20250301
+DTEND;VALUE=DATE:20250302
+SUMMARY:JSConf España 2025
+URL:https://www.jsconf.es/
+DESCRIPTION:¡Únete a JSConf España 2025!\n📅 Fecha: 1 de marzo de 2025\n📍 Lugar: La Nave\, C. Cifuentes\, 5\, Villaverde\, 28021 Madrid\, España\n\n¿Listo para sumergirte en el futuro de JavaScript? 🚀 JSConf España es el evento imperdible para desarrolladores\, entusiastas y profesionales que viven y respiran JavaScript.\n\n✨ ¿Qué te espera?\n\n    🌐 Charlas inspiradoras: Aprende de los líderes de la industria y de las mentes más brillantes del ecosistema JavaScript.\n    🤝 Networking: Conecta con una comunidad vibrante de desarrolladores\, comparte ideas y encuentra nuevas oportunidades.\n    🎉 Actividades especiales: Talleres\, paneles y\, por supuesto\, ¡momentos para divertirse!\n\nYa seas un principiante o un experto\, JSConf España tiene algo para ti. No te pierdas la oportunidad de expandir tus habilidades\, descubrir las últimas tendencias y ser parte de una comunidad que está transformando la web.\n\n🔗 Reserva tu entrada ahora: https://www.jsconf.es/\n¡Nos vemos allí!
+LOCATION:La Nave\, Madrid
+BEGIN:VALARM
+ACTION:DISPLAY
+DESCRIPTION:JSConf España 2025
+TRIGGER:-P1D
+END:VALARM
+END:VEVENT
+END:VCALENDAR

--- a/src/sections/Agenda.astro
+++ b/src/sections/Agenda.astro
@@ -4,11 +4,6 @@ import agendaData from '@/data/agenda.json'
 import Talk from '@/components/Talk.astro'
 import Break from '@/components/Break.astro'
 import Calendar from '@/icons/Calendar.svg'
-const eventTitle = encodeURIComponent('JSConf España 2025')
-const eventStart = encodeURIComponent('20250301T1000')
-const eventEnd = encodeURIComponent('20250301T1900')
-const eventDetails = encodeURIComponent('Una experiencia exclusiva de JavaScript')
-const eventLocation = encodeURIComponent('La Nave, Madrid')
 ---
 
 <section id="agenda" class="bg-black flex flex-col px-section text-white font-clash">
@@ -24,7 +19,7 @@ const eventLocation = encodeURIComponent('La Nave, Madrid')
                 class="text-javascript hover:text-javascript-dark font-medium flex items-center gap-x-2"
                 id="add-to-calendar"
                 target="_blank"
-                href={`https://calendar.google.com/calendar/r/eventedit?text=${eventTitle}&dates=${eventStart}/${eventEnd}&details=${eventDetails}&location=${eventLocation}`}
+                href="/jsconfes.ics"
               >
                 <Calendar class="size-6" />
                 Agregalo a tu calendario


### PR DESCRIPTION
Cambiado el evento de Google Calendar por un archivo ICS para soportar todas las aplicaciones de calendario.

Resultado del ICS:
![image](https://github.com/user-attachments/assets/3d0464e8-8af6-4002-9d47-07a58b4659f2)
