### PR TITLE
fix: adjust image width for better responsiveness

### DIFF
--- a/src/sections/RunAndFun.astro
+++ b/src/sections/RunAndFun.astro
@@ -91,7 +91,7 @@ import InfoTag from '@/components/InfoTag.astro'
             </a>
           </div>
         </div>
-        <img src="/img/midu-run.webp" alt="Midu corriendo" class="max-lg:hidden object-contain" />
+        <img src="/img/midu-run.webp" alt="Midu corriendo" class="max-lg:hidden object-contain lg:max-w-[50%]" />
         <img
           src="/img/midu-run-mobile.webp"
           alt="Midu corriendo"


### PR DESCRIPTION
Ajuste del max-width para evitar el desbordamiento de la imagen principal en la seccion de la carrera en la version desktop

Antes:
![imagen](https://github.com/user-attachments/assets/41deb986-ecb2-4a74-a50f-37b87eeb2095)

Despues:
![imagen](https://github.com/user-attachments/assets/5a6b891d-9990-4556-a472-decf5dc6b8a2)
