### PR TITLE
style: adjust image object class for SpeakerCard component

### DIFF
--- a/src/components/SpeakerCard.astro
+++ b/src/components/SpeakerCard.astro
@@ -13,7 +13,7 @@ const { name, role, company, description, imageUrl, companyLogo: Logo, marginTop
 ---
 
 <div class="card font-clash bg-black text-white">
-  <img src={imageUrl} alt={name} class="w-full object-scale-down" />
+  <img src={imageUrl} alt={name} class="w-full" />
   <div class="flex flex-col md:gap-y-[14px] gap-y-[6px] border border-white/10 md:p-6 p-3">
     <div>
       <div class="flex flex-row items-center justify-between">


### PR DESCRIPTION
Antes en pantallas medianas el scale down hacía que las imagenes no cubriesen todo su area:
![image](https://github.com/user-attachments/assets/4287e87e-8ee5-453c-8096-3c17f310d4d7)

Ahora:
![image](https://github.com/user-attachments/assets/4fbf92e6-bf1b-4c5d-ac6d-ce37a67c17fc)
