### PR TITLE
Fix: add rel='noreferrer' to target='_blank' link

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -30,7 +30,7 @@ import MiduLogoIcon from '@/icons/MiduLogo.svg'
         <a
           class="flex flex-row gap-x-2 justify-center items-center transition-transform hover:scale-110"
           href="https://midu.dev/"
-          rel="noopener"
+          rel="noopener noreferrer"
           target="_blank"
         >
           <MiduLogoIcon /><strong class="font-semibold">midudev</strong>


### PR DESCRIPTION
## Descripción
Se agregó `rel="noopener noreferrer"`al enlace para mitigar riesgos de seguridad.

## Motivación
Evitar que las nuevas pestañas accedan a `window.opener`, lo que podría permitir ataques de tipo phising o manipulación de la página original.

## Cambios realizados
- Añadí el atributo `noreferrer` al enlace.

## Pruebas realizadas
- Verifiqué manualmente el enlace afectado.
- No se rompió ningún comportamiento existente.