### PR TITLE
fix: hover over "Agregalo a tu calendario"

### DIFF
--- a/src/components/AddToCalendarDialog.astro
+++ b/src/components/AddToCalendarDialog.astro
@@ -41,7 +41,7 @@ const calendars = [
     Agregalo a tu calendario
   </Button>
   <div
-    class="hidden absolute top-full left-0 group-hover:flex group-focus-within:flex flex-col items-center justify-center gap-y-2 w-full bg-zinc-950"
+    class="hidden absolute overflow-hidden z-10 rounded-b-md top-full left-0 group-hover:flex group-focus-within:flex flex-col items-center justify-center gap-y-2 w-full bg-zinc-950"
     id="calendar-dialog"
   >
     {


### PR DESCRIPTION
La sección difuminada de abajo estaba por encima del componente y al hacer hover éste se cerraba.
Tambien redondeé los bordes inferiores

https://github.com/user-attachments/assets/69780211-c63c-4cbb-9c93-ec25a038701f

