### PR TITLE
Style: Add aspect ratio to speaker image for improved layout consistency

### DIFF
--- a/src/components/SpeakerCard.astro
+++ b/src/components/SpeakerCard.astro
@@ -13,7 +13,7 @@ const { name, role, company, description, imageUrl, companyLogo: Logo, marginTop
 ---
 
 <div class="card font-clash bg-black text-white">
-  <img src={imageUrl} alt={name} class="w-full" />
+  <img src={imageUrl} alt={name} class="w-full aspect-square" />
   <div class="flex flex-col md:gap-y-[14px] gap-y-[6px] border border-white/10 md:p-6 p-3">
     <div>
       <div class="flex flex-row items-center justify-between">


### PR DESCRIPTION
Uso de aspect ratio en las imagenes de los speakers para que las imagenes guarden su lugar al cargar la pagina

Antes:

https://github.com/user-attachments/assets/9f0358ad-935a-4727-839f-fb23c0ecb7d2

Despues:

https://github.com/user-attachments/assets/81ded022-0b6a-44a4-a316-a0fa052d3dd4