### PR TITLE
Feat: tito setup and modal

### DIFF
--- a/public/css/tito-widget.css
+++ b/public/css/tito-widget.css
@@ -1,6 +1,38 @@
 .tito-form input[type='text'],
-.tito-form input[type='email'] {
+.tito-form input[type='email'],
+.tito-share input[type='text'],
+.tito-ticket-show input {
   background-color: white;
+}
+
+.tito-overlay .tito-registration .tito-continue-button,
+.tito-overlay .tito-ticket-show .tito-choose-me,
+.tito-overlay .tito-ticket-show .tito-choose-somebody,
+.tito-overlay .tito-ticket-show .tito-ticket-show--footer .tito-ticket-show--submit,
+.tito-overlay .tito-upgrade-choose-button {
+  background-color: #f7df1e;
+  border-color: #f7df1e !important;
+  color: black;
+}
+
+.tito-overlay .tito-registration .tito-continue-button:active,
+.tito-overlay .tito-registration .tito-continue-button:hover,
+.tito-overlay .tito-registration .tito-continue-button:visited,
+.tito-overlay .tito-ticket-show .tito-choose-me:active,
+.tito-overlay .tito-ticket-show .tito-choose-me:hover,
+.tito-overlay .tito-ticket-show .tito-choose-me:visited,
+.tito-overlay .tito-ticket-show .tito-choose-somebody:active,
+.tito-overlay .tito-ticket-show .tito-choose-somebody:hover,
+.tito-overlay .tito-ticket-show .tito-choose-somebody:visited,
+.tito-overlay .tito-ticket-show .tito-ticket-show--footer .tito-ticket-show--submit:active,
+.tito-overlay .tito-ticket-show .tito-ticket-show--footer .tito-ticket-show--submit:hover,
+.tito-overlay .tito-ticket-show .tito-ticket-show--footer .tito-ticket-show--submit:visited,
+.tito-overlay .tito-upgrade-choose-button:active,
+.tito-overlay .tito-upgrade-choose-button:hover,
+.tito-overlay .tito-upgrade-choose-button:visited {
+  background: #ebd41d;
+  border-color: #ebd41d !important;
+  color: black;
 }
 
 .tito-overlay .tito-registration .tito-registration-header h1 {

--- a/public/css/tito-widget.css
+++ b/public/css/tito-widget.css
@@ -1,0 +1,887 @@
+.tito-form input[type='text'],
+.tito-form input[type='email'] {
+  background-color: white;
+}
+
+.tito-overlay .tito-registration .tito-registration-header h1 {
+  font-family: 'Clash', sans-serif;
+  font-size: 34px !important;
+  font-weight: 500 !important;
+  line-height: 1.2;
+}
+
+.tito-overlay .tito-registration .tito-registration-header {
+  align-items: center;
+  background: white;
+  border: none;
+  display: flex;
+  justify-content: center;
+  line-height: 1.2;
+  padding: 20px 10px;
+  text-align: start;
+  width: 100%;
+}
+
+.tito-registration .tito-widget .tito-widget-form {
+  background-color: #fff;
+  width: 100%;
+}
+
+.mcdonagh-theme .tito-widget {
+  margin: 0;
+}
+
+.mcdonagh-theme .tito-widget .tito-widget-form {
+  background-color: #fff;
+  border: none;
+  border-radius: 0;
+  max-width: none;
+}
+
+.mcdonagh-theme .tito-widget .tito-widget-form .tito-release {
+  border-color: #eff0f2;
+}
+
+.classic-theme .tito-widget {
+  margin: 0;
+}
+
+.classic-theme .tito-widget .tito-widget-form {
+  background-color: transparent;
+  border: none;
+  border-radius: 0;
+  max-width: none;
+  padding: 0;
+}
+
+.classic-theme .tito-widget .tito-widget-form .tito-release {
+  border-color: #bec7cf;
+}
+
+.classic-theme .tito-widget .tito-widget-form .tito-form-actions {
+  padding-bottom: 5px;
+}
+
+.tito-widget {
+  color: #333;
+  display: flex;
+  justify-content: center;
+  margin-bottom: 20px;
+  margin-top: 20px;
+  width: 100%;
+}
+
+.tito-widget body,
+.tito-widget fieldset,
+.tito-widget form,
+.tito-widget html,
+.tito-widget legend,
+.tito-widget li,
+.tito-widget ol,
+.tito-widget ul {
+  margin: 0;
+  padding: 0;
+}
+
+.tito-widget h1 {
+  font-family: 'Clash', sans-serif;
+}
+
+.tito-widget h1,
+.tito-widget h2,
+.tito-widget h3,
+.tito-widget h4,
+.tito-widget h5,
+.tito-widget h6 {
+  font-weight: 700;
+}
+
+.tito-widget h1,
+.tito-widget h2,
+.tito-widget h3,
+.tito-widget h4,
+.tito-widget h5,
+.tito-widget h6,
+.tito-widget p {
+  margin-top: 0;
+  text-transform: none;
+}
+
+.tito-widget h2 {
+  font-size: 1.17em;
+  line-height: 1.23em;
+}
+
+.tito-widget a,
+.tito-widget p {
+  font-size: 1em;
+  line-height: 1.23em;
+}
+
+.tito-widget a {
+  z-index: auto;
+}
+
+.tito-widget fieldset,
+.tito-widget img {
+  border: 0;
+}
+
+.tito-widget legend {
+  color: #000;
+}
+
+.tito-widget li {
+  list-style: none;
+}
+
+.tito-widget sup {
+  vertical-align: text-top;
+}
+
+.tito-widget sub {
+  vertical-align: text-bottom;
+}
+
+.tito-widget table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+.tito-widget caption,
+.tito-widget td,
+.tito-widget th {
+  font-weight: 400;
+  text-align: left;
+  vertical-align: top;
+}
+
+.tito-widget input,
+.tito-widget select,
+.tito-widget textarea {
+  font-size: 16px;
+  line-height: 1.1;
+}
+
+.tito-widget abbr,
+.tito-widget acronym {
+  border-bottom: 0.1em dotted;
+  cursor: help;
+}
+
+.tito-widget b,
+.tito-widget strong {
+  font-weight: 700;
+}
+
+.tito-widget * {
+  box-sizing: border-box;
+}
+
+@media (max-width: 37.5em) {
+  .tito-widget {
+    font-size: 13px;
+  }
+}
+
+.tito-flow .tito-widget {
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.tito-widget input[type='number']::-webkit-inner-spin-button,
+.tito-widget input[type='number']::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.tito-widget input[type='number'],
+.tito-widget input[type='text'] {
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+  color: #333;
+  display: inline-block;
+  font-size: 16px;
+  height: 34px;
+  line-height: 1.42857143;
+  margin: 0;
+  text-align: center;
+}
+
+.tito-widget .tito-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: end;
+  padding: 20px 0;
+  text-align: right;
+}
+
+.tito-widget .tito-form-actions.tito-form-actions--with-discount {
+  justify-content: start;
+}
+
+.tito-widget .tito-form-actions .tito-discount {
+  flex: 1;
+  margin-bottom: 20px;
+  min-width: 100%;
+  text-align: left;
+  transition: flex 0.5s;
+}
+
+@media (min-width: 37.5em) {
+  .tito-widget .tito-form-actions .tito-discount {
+    margin-bottom: inherit;
+    min-width: inherit;
+  }
+}
+
+.tito-widget .tito-form-actions .tito-discount.tito-discount--applying {
+  flex: 0;
+}
+
+.tito-widget .tito-form-actions .tito-discount input.tito-discount-code-field {
+  padding-left: 10px;
+  text-align: left;
+  width: 100%;
+}
+
+@media (min-width: 37.5em) {
+  .tito-widget .tito-form-actions .tito-discount input.tito-discount-code-field {
+    margin-right: 10px;
+    width: inherit;
+  }
+}
+
+.tito-widget .tito-form-actions .tito-discount input.tito-discount-code-field[disabled] {
+  background-color: #a4a4a7;
+}
+
+.tito-widget .tito-form-actions .tito-discount input.tito-discount-code-field.tito-invalid {
+  border-color: #e12328;
+}
+
+.tito-widget .tito-form-actions .tito-discount .tito-discount--warning {
+  color: #e12328;
+  line-height: 34px;
+  white-space: nowrap;
+}
+
+.tito-widget .tito-form-actions .tito-submit {
+  font-family: 'Clash', sans-serif;
+  font-weight: 500;
+  background: #f7df1f;
+  color: black;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1.42857143;
+  margin: 0;
+  min-height: 34px;
+  padding: 6px 12px;
+  text-align: center;
+  width: 100%;
+}
+
+.tito-widget .tito-form-actions .tito-submit:active,
+.tito-widget .tito-form-actions .tito-submit:focus,
+.tito-widget .tito-form-actions .tito-submit:hover {
+  background: #ecd41d;
+}
+
+@media (min-width: 37.5em) {
+  .tito-widget .tito-form-actions .tito-submit {
+    max-width: min-content;
+    min-width: 145px;
+  }
+}
+
+.tito-widget .tito-form-actions .tito-submit.tito-submit--discount-code {
+  background: #1a8754;
+  border-color: #167247 !important;
+  color: #fff;
+  padding-bottom: 0;
+  padding-top: 0;
+}
+
+.tito-widget .tito-form-actions .tito-submit[disabled] {
+  background-color: #aaa;
+  border: none;
+  color: #717075;
+}
+
+.tito-widget .tito-form-actions .tito-submit[disabled]:hover {
+  color: #717075;
+}
+
+.tito-widget .tito-locked-ticket-message {
+  background-color: #fdefde;
+  border: 1px solid #f6af58;
+  border-radius: 4px;
+  color: #805b2e;
+  margin-top: 20px;
+  padding: 10px;
+  text-align: center;
+}
+
+.tito-widget .tito-locked-ticket-message p {
+  line-height: 1.4;
+  margin-bottom: 0;
+}
+
+.tito-widget .tito-locked-ticket-message p + p {
+  margin-top: 5px;
+}
+
+.tito-widget .tito-widget-registration-unavailable {
+  font-weight: 700;
+  margin: 20px 0;
+  text-align: center;
+}
+
+.tito-widget .tito-widget-loading {
+  padding: 20px;
+}
+
+.tito-widget .tito-widget-form {
+  background: #fafafa;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  max-width: 920px;
+  padding-left: 10px;
+  padding-right: 10px;
+  width: 100%;
+}
+
+@media (min-width: 37.5em) {
+  .tito-widget .tito-widget-form {
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+}
+
+.tito-widget-in-overlay .tito-widget .tito-widget-form {
+  border: none;
+  border-radius: 0;
+}
+
+.tito-widget .tito-widget-form .tito-times {
+  align-items: center;
+  display: none;
+  margin-left: 5px;
+  opacity: 0.5;
+}
+
+@media (max-width: 37.5em) {
+  .tito-widget .tito-widget-form .tito-times {
+    display: none;
+  }
+}
+
+@media (min-width: 37.5em) {
+  .tito-widget .tito-widget-form .tito-times {
+    margin-left: 10px;
+    margin-right: 5px;
+  }
+}
+
+.tito-widget .tito-widget-form .tito-release {
+  background-color: #f7f7f7;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px;
+  margin-top: 10px;
+  min-height: 54px;
+}
+
+.tito-widget .tito-widget-form .tito-release h1 {
+  font-family: 'Clash', sans-serif;
+  font-weight: 700;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-release-description {
+  row-gap: 18px;
+}
+
+@media (max-width: 37.5em) {
+  .tito-widget .tito-widget-form .tito-release {
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+}
+
+@media (min-width: 37.5em) {
+  .tito-widget .tito-widget-form .tito-release {
+    margin-top: 0;
+  }
+}
+
+.tito-widget .tito-widget-form .tito-release.tito-release--expired,
+.tito-widget
+  .tito-widget-form
+  .tito-release.tito-release--expired
+  .tito-release-description
+  .tito-release-description--combos,
+.tito-widget
+  .tito-widget-form
+  .tito-release.tito-release--expired
+  .tito-release-description
+  .tito-release-description--description
+  p,
+.tito-widget .tito-widget-form .tito-release.tito-release--locked,
+.tito-widget
+  .tito-widget-form
+  .tito-release.tito-release--locked
+  .tito-release-description
+  .tito-release-description--combos,
+.tito-widget
+  .tito-widget-form
+  .tito-release.tito-release--locked
+  .tito-release-description
+  .tito-release-description--description
+  p,
+.tito-widget .tito-widget-form .tito-release.tito-release--sold-out,
+.tito-widget
+  .tito-widget-form
+  .tito-release.tito-release--sold-out
+  .tito-release-description
+  .tito-release-description--combos,
+.tito-widget
+  .tito-widget-form
+  .tito-release.tito-release--sold-out
+  .tito-release-description
+  .tito-release-description--description
+  p,
+.tito-widget .tito-widget-form .tito-release.tito-release--upcoming,
+.tito-widget
+  .tito-widget-form
+  .tito-release.tito-release--upcoming
+  .tito-release-description
+  .tito-release-description--combos,
+.tito-widget
+  .tito-widget-form
+  .tito-release.tito-release--upcoming
+  .tito-release-description
+  .tito-release-description--description
+  p {
+  color: #717075;
+}
+
+.tito-widget .tito-widget-form .tito-release.tito-release--locked .tito-release--status {
+  background-color: #fdefde;
+  border-color: #f6af58;
+  color: #805b2e;
+}
+
+.tito-widget .tito-widget-form .tito-release.tito-release--upcoming .tito-release--status {
+  padding: 1px 1rem;
+}
+
+.tito-widget .tito-widget-form .tito-release.tito-release:last-child {
+  border: none;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-release--title {
+  font-family: 'Clash', sans-serif;
+  font-weight: 500;
+  font-size: 18px;
+  margin-bottom: 0;
+  width: 100%;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-details--waiting-list,
+.tito-widget .tito-widget-form .tito-release .tito-price-details-donation {
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-details--waiting-list .tito-release--tax,
+.tito-widget .tito-widget-form .tito-release .tito-price-details-donation .tito-release--tax,
+.tito-widget .tito-widget-form .tito-release .tito-price-details-regular .tito-release--tax {
+  color: rgba(0, 0, 0, 0.75);
+  font-size: 11px;
+  text-align: right;
+  width: 100%;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-details--waiting-list
+  .tito-release--donation-currency,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-price-details-donation
+  .tito-release--donation-currency,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-price-details-regular
+  .tito-release--donation-currency {
+  margin-right: 5px;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-details--waiting-list
+  .tito-release--donation-input,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-price-details-donation
+  .tito-release--donation-input,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-price-details-regular
+  .tito-release--donation-input {
+  -moz-appearance: textfield;
+  max-width: 100px;
+}
+
+@media (max-width: 37.5em) {
+  .tito-widget
+    .tito-widget-form
+    .tito-release
+    .tito-details--waiting-list
+    .tito-release--donation-input,
+  .tito-widget
+    .tito-widget-form
+    .tito-release
+    .tito-price-details-donation
+    .tito-release--donation-input,
+  .tito-widget
+    .tito-widget-form
+    .tito-release
+    .tito-price-details-regular
+    .tito-release--donation-input {
+    max-width: 55px;
+  }
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-details--waiting-list
+  .tito-release--donation-input:disabled,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-price-details-donation
+  .tito-release--donation-input:disabled,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-price-details-regular
+  .tito-release--donation-input:disabled {
+  background: #efefef;
+  color: #aaa;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-details--waiting-list .tito-price,
+.tito-widget .tito-widget-form .tito-release .tito-price-details-donation .tito-price,
+.tito-widget .tito-widget-form .tito-release .tito-price-details-regular .tito-price {
+  padding: 0;
+  text-align: right;
+  width: 100%;
+}
+
+@media (max-width: 37.5em) {
+  .tito-widget .tito-widget-form .tito-release .tito-details--waiting-list .tito-price,
+  .tito-widget .tito-widget-form .tito-release .tito-price-details-donation .tito-price,
+  .tito-widget .tito-widget-form .tito-release .tito-price-details-regular .tito-price {
+    text-align: left;
+  }
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-details--waiting-list .tito-discounted-from,
+.tito-widget .tito-widget-form .tito-release .tito-price-details-donation .tito-discounted-from,
+.tito-widget .tito-widget-form .tito-release .tito-price-details-regular .tito-discounted-from {
+  color: #e12328;
+  margin-right: 5px;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-details--waiting-list {
+  margin-right: 0;
+}
+
+@media (max-width: 37.5em) {
+  .tito-widget .tito-widget-form .tito-release .tito-details--waiting-list,
+  .tito-widget
+    .tito-widget-form
+    .tito-release
+    .tito-details--waiting-list
+    .tito-choose-waiting-list-button,
+  .tito-widget .tito-widget-form .tito-release .tito-details--waiting-list .tito-quantity {
+    width: 100%;
+  }
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-price-details-donation {
+  flex-direction: column;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-release--status {
+  background-color: #fff;
+  border: 1px solid #717075;
+  border-radius: 2px;
+  color: #717075;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  line-height: 22px;
+  margin: auto auto auto 18px;
+  min-width: 143px;
+  padding: 5px 1rem;
+  text-align: center;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+@media (max-width: 37.5em) {
+  .tito-widget .tito-widget-form .tito-release .tito-release--status {
+    margin: 0 0 0 5px;
+    min-width: 100px;
+  }
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-release--status span {
+  display: block;
+  margin-top: -6px;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-release-title {
+  width: 100%;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-release-description {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  flex: 1;
+  flex-wrap: wrap;
+  padding-bottom: 10px;
+  padding-right: 15px;
+  padding-top: 10px;
+}
+
+@media (max-width: 37.5em) {
+  .tito-widget .tito-widget-form .tito-release .tito-release-description {
+    min-width: 100%;
+    padding-right: 0;
+  }
+}
+
+@media (min-width: 37.5em) {
+  .tito-widget .tito-widget-form .tito-release .tito-release-description {
+    min-width: inherit;
+    padding-right: 20px;
+  }
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-release-description .tito-release--combo-label {
+  background-color: #ccc;
+  border-radius: 10px;
+  padding: 2px 10px;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-release-description
+  .tito-release-description--description {
+  min-width: 100%;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-release-description
+  .tito-release-description--description
+  p {
+  color: #555;
+  font-size: 14px;
+  line-height: 1.3;
+  margin-bottom: 15px;
+  margin-top: 5px;
+  max-width: 60ch;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-release-description
+  .tito-release-description--description
+  p:last-of-type {
+  margin-bottom: 0;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-release-description
+  .tito-release-description--combos {
+  color: #555;
+  margin-top: 10px;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-release-description
+  .tito-release-description--combos
+  ul {
+  margin-top: 2px;
+  padding-inline-start: 20px;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-release-description
+  .tito-release-description--combos
+  li {
+  list-style-type: disc;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-release-description
+  p.tito-release-description--degressive-prices-description {
+  flex-basis: 100%;
+  font-size: 12px;
+  margin-bottom: 0;
+  margin-top: 5px;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-quantity {
+  align-items: center;
+  display: flex;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-quantity .tito-choose-waiting-list-button {
+  background-color: #fff;
+  border: 1px solid #27272a;
+  border-radius: 4px;
+  color: #27272a;
+  cursor: pointer;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  line-height: 22px;
+  margin: auto;
+  min-width: 143px;
+  padding: 5px 0;
+  text-align: center;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-quantity .tito-choose-waiting-list-button:hover {
+  background-color: #27272a;
+  color: #fff;
+  text-decoration: none;
+}
+
+@media (min-width: 37.5em) {
+  .tito-widget .tito-widget-form .tito-release .tito-quantity .tito-choose-waiting-list-button {
+    margin-left: 18px;
+  }
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-quantity .tito-release--decrement-quantity--link,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-quantity
+  .tito-release--increment-quantity--link {
+  border-bottom: none !important;
+  text-decoration: none;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-quantity .tito-release--decrement-quantity > a,
+.tito-widget .tito-widget-form .tito-release .tito-quantity .tito-release--increment-quantity > a {
+  align-items: center;
+  color: #000000;
+  display: flex;
+  height: 30px;
+  justify-content: center;
+  text-decoration: none;
+  width: 30px;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-quantity
+  .tito-release--decrement-quantity
+  > a:active,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-quantity
+  .tito-release--decrement-quantity
+  > a:visited,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-quantity
+  .tito-release--increment-quantity
+  > a:active,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-quantity
+  .tito-release--increment-quantity
+  > a:visited {
+  color: #27272a;
+  text-decoration: none;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-quantity
+  .tito-release--decrement-quantity
+  > a:hover,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-quantity
+  .tito-release--increment-quantity
+  > a:hover {
+  color: #27272a;
+}
+
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-quantity
+  .tito-release--decrement-quantity
+  > a.tito-release--decrement-quantity--link--disabled,
+.tito-widget
+  .tito-widget-form
+  .tito-release
+  .tito-quantity
+  .tito-release--increment-quantity
+  > a.tito-release--decrement-quantity--link--disabled {
+  color: #717075;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-quantity .tito-quantity-input {
+  -moz-appearance: textfield;
+  boder: none;
+  width: 45px;
+}
+
+.tito-widget .tito-widget-form .tito-release .tito-quantity .tito-release--quantity-input {
+  margin-left: 15px;
+}

--- a/src/components/LinkEntrada.astro
+++ b/src/components/LinkEntrada.astro
@@ -1,11 +1,17 @@
 ---
 import Ticket from '@/icons/Ticket.svg'
 import Button from '@/components/Button.astro'
-import { COMPRAR_ENTRADA } from '@/consts/links'
 const { style = 'black' } = Astro.props
 ---
 
-<Button href={COMPRAR_ENTRADA} style={style}>
-  <span> ¡Consigue tu entrada! </span>
-  <Ticket slot="icon-left" />
-</Button>
+<tito-button event="js-conf/js-conf-2025" discount-code="EARLY">
+  <Button style={style}>
+    <span> ¡Consigue tu entrada! </span>
+    <Ticket slot="icon-left" />
+  </Button>
+</tito-button>
+<style is:inline>
+  .tito-widget-button {
+    width: 100%;
+  }
+</style>

--- a/src/components/LinkEntrada.astro
+++ b/src/components/LinkEntrada.astro
@@ -4,7 +4,7 @@ import Button from '@/components/Button.astro'
 const { style = 'black' } = Astro.props
 ---
 
-<tito-button event="js-conf/js-conf-2025" discount-code="EARLY">
+<tito-button class="w-full md:w-auto" event="js-conf/js-conf-2025" discount-code="EARLY">
   <Button style={style}>
     <span> ¡Consigue tu entrada! </span>
     <Ticket slot="icon-left" />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -85,7 +85,8 @@ const title = Astro.props.title
         }
       }
     </script>
-    <script src="https://js.tito.io/v2" async></script>
+    <script src="https://js.tito.io/v2/with/inline/without/widget-css" async></script>
+    <link rel="stylesheet" href="/css/tito-widget.css" />
   </head>
   <body class="relative">
     <div

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -85,6 +85,7 @@ const title = Astro.props.title
         }
       }
     </script>
+    <script src="https://js.tito.io/v2" async></script>
   </head>
   <body class="relative">
     <div


### PR DESCRIPTION
Se añade el botón embebido de tito para pagar directamente desde la página.

He logrado modificar algo el modal para que siga la temática:
![image](https://github.com/user-attachments/assets/83982fa7-cb7e-4959-9012-7b5305e91e53)
![image](https://github.com/user-attachments/assets/8764757a-31fc-4aed-8bc9-dee60ec3af32)
![image](https://github.com/user-attachments/assets/38023617-128c-4194-8316-6386c6eef38c)
![image](https://github.com/user-attachments/assets/edfcd805-7bcd-42f4-bd0f-f947940bb663)
![image](https://github.com/user-attachments/assets/cb4f35e6-0fa8-4817-a353-22e850ca3329)



Para ello he seguido la guía de tito: https://ti.to/docs/api/widget#tito-widget-v2-basic-usage
He deshabilitado que importe el css del widget y creado yo un fichero css en el que están todas las clases necesarias del fichero que ya no se importa. Esto me ha permitido editar ahí las clases para modificar la apariencia.

Las modificaciones son muy limitadas, así q he hecho lo que se ha podido.

Versión anterior:
![image](https://github.com/user-attachments/assets/0a278bc4-d5a6-49cb-bf97-4d4c10a44de2)

@midudev revisa la integración por favor por si he hecho algo mal :)