### PR TITLE
Fix: delete unnecesary classes and add nav height

### DIFF
--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -44,13 +44,13 @@ const sections = [
     </div>
     <HamburgerButton class:list="block lg:hidden" id="menuButton" />
     <div
-      class="fixed inset-0 z-[888] flex w-screen h-screen flex-col items-center overflow-x-auto lg:hidden backdrop-blur-lg bg-black/85"
+      class="fixed inset-0 z-[888] flex w-screen flex-col items-center overflow-x-auto lg:hidden backdrop-blur-lg bg-black/85"
       id={MOBILE_MENU_CONTENT_ID}
     >
       <aside class="flex min-h-16 w-full items-center justify-end px-6 pt-6">
         <HamburgerButton id="innerMenuButton" />
       </aside>
-      <nav class="navContent flex w-full flex-col items-start justify-end px-6 gap-5 mt-auto mb-8">
+      <nav class="navContent flex w-full h-full flex-col items-start justify-end px-6 gap-5 mb-8">
         {
           sections.map(({ name, href }, key) => (
             <>


### PR DESCRIPTION
## Descripción
Se borraron las clases `h-screen` (div contenedor del nav) y `mt-auto` (nav) para resolver el problema de visibilidad en la versión móvil. Además, se añadió una altura del 100% al nav.

## Motivación
Resolver el problema de visibilidad de los botones en la versión móvil.

## Cambios realizados
- Borrar la clase `h-screen` del componente padre del nav.
- Borrar la clase `mt-auto`del nav.
- Añadir la clase `h-full`al nav.

## Pruebas realizadas
- Verificar manualmente en móvil.
- No afectó a la versión de escritorio.

## Screenshots

| Before  | Now |
| ------------- | ------------- |
| ![Screenshot_20241218_095317_Chrome](https://github.com/user-attachments/assets/8f3f76fc-751a-42c3-a6bf-11d906a42a50)  | ![Screenshot_20241218_095404_Chrome](https://github.com/user-attachments/assets/2fddd256-0b5c-4091-9ff2-620d94375099)  |
