### PR TITLE
style: adjust mobile menu to dynamic viewport height

### DIFF
--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -44,7 +44,7 @@ const sections = [
     </div>
     <HamburgerButton class:list="block lg:hidden" id="menuButton" />
     <div
-      class="fixed inset-0 z-[888] flex w-screen flex-col items-center overflow-x-auto lg:hidden backdrop-blur-lg bg-black/85"
+      class="fixed inset-0 z-[888] flex w-screen h-[100dvh] flex-col items-center overflow-x-auto lg:hidden backdrop-blur-lg bg-black/85"
       id={MOBILE_MENU_CONTENT_ID}
     >
       <aside class="flex min-h-16 w-full items-center justify-end px-6 pt-6">


### PR DESCRIPTION
La anterior pr https://github.com/midudev/jsconf.es/pull/72 conseguía que en móviles no se desbordase el menú. Pero después de probar he visto que si se abre el menú sin estar arriba del todo, el menú tiene la misma altura que el header.

![imagen](https://github.com/user-attachments/assets/15c4c04f-53a4-4748-a5db-014e7eb1b3ff)

Para solucionarlo, he remplazado el h-screen que utilizábamos en la versión anterior a dicha pr, por h-[100dvh] el cual tiene en cuenta las barras  del navegador y no provoca overflow. El overflow que pasaba antes se producía porq h-screen al ser 100vh no tenía en cuenta la barra del navegador.

Más información: https://web.dev/blog/viewport-units?hl=es-419