### PR TITLE
fix: speakers card now have same height in small screens

### DIFF
--- a/src/components/SpeakerCard.astro
+++ b/src/components/SpeakerCard.astro
@@ -22,7 +22,7 @@ const {
 } = Astro.props as CardProps
 ---
 
-<article class="card font-clash text-white select-none cursor-crosshair">
+<article class="card flex flex-col h-full font-clash text-white select-none cursor-crosshair">
   <figure class="effect relative overflow-hidden">
     <Image
       inferSize
@@ -39,7 +39,7 @@ const {
     </figcaption>
   </figure>
   <div
-    class="flex flex-col md:gap-y-[14px] gap-y-[6px] bg-white/5 border border-white/10 md:p-6 p-3"
+    class="flex flex-col flex-1 md:gap-y-[14px] gap-y-[6px] bg-white/5 border border-white/10 md:p-6 p-3"
   >
     <div>
       <div class="flex flex-row items-center justify-between">


### PR DESCRIPTION
Antes:
![image](https://github.com/user-attachments/assets/79f321e1-214b-4d33-a035-fc955718c256)

Ahora:
![image](https://github.com/user-attachments/assets/555a97ae-7179-4f9f-a6e8-f8239c9481a4)
