### PR TITLE
feat: container class and some tweaks

### DIFF
--- a/src/components/Container.astro
+++ b/src/components/Container.astro
@@ -2,6 +2,6 @@
 const { class: className } = Astro.props
 ---
 
-<div class:list={['flex flex-col mx-auto max-w-[90rem] py-12', className]}>
+<div class:list={['flex flex-col px-4 lg:md-0 mx-auto container py-12', className]}>
   <slot />
 </div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -12,7 +12,7 @@ import { Image } from 'astro:assets'
 <div class="relative min-h-screen flex flex-col items-center justify-center px-4 text-center">
   <div class="space-y-8 pt-24">
     <h1
-      class="text-6xl md:text-8xl font-clash font-[550] bg-gradient-to-r from-white/50 via-white to-white/70 inline-block text-transparent bg-clip-text"
+      class="text-6xl md:text-8xl font-clash font-[550] bg-gradient-to-r from-white/40  via-white  to-white/25  inline-block text-transparent bg-clip-text"
     >
       JSConf España 2025
     </h1>

--- a/src/components/SpeakerCard.astro
+++ b/src/components/SpeakerCard.astro
@@ -8,7 +8,10 @@ export interface CardProps {
   description: string
   imageUrl: string
   companyLogo: string | any
-  marginTop?: string
+  marginTop?: {
+    xl?: string
+    lg?: string
+  }
 }
 
 const {
@@ -18,7 +21,7 @@ const {
   description,
   imageUrl,
   companyLogo: Logo,
-  marginTop,
+  marginTop = {},
 } = Astro.props as CardProps
 ---
 
@@ -61,9 +64,9 @@ const {
   </div>
 </article>
 
-<style define:vars={{ marginTop }}>
+<style define:vars={{ marginTopXl: marginTop.xl, marginTopLg: marginTop.lg }}>
   .card {
-    margin-top: var(--marginTop);
+    margin-top: var(--marginTopXl);
   }
   figure.effect {
     background: #000;
@@ -144,6 +147,12 @@ const {
   @media (max-width: 1024px) {
     .card {
       margin-top: 0;
+    }
+  }
+
+  @media (max-width: 1280px) {
+    .card {
+      margin-top: var(--marginTopLg);
     }
   }
 </style>

--- a/src/sections/Agenda.astro
+++ b/src/sections/Agenda.astro
@@ -9,7 +9,7 @@ import AddToCalendarDialog from '@/components/AddToCalendarDialog.astro'
 <section id="agenda" class="bg-black flex flex-col px-section text-white font-clash scroll-mt-28">
   <Container class="w-full">
     <div class="flex gap-4 justify-between pb-6 flex-col md:flex-row md:items-center">
-      <h3 class="text-5xl font-semibold">Programa del evento</h3>
+      <h3 class="text-5xl ">Programa del evento</h3>
       <div class="flex items-center">
         {
           agendaData.map((day) => (

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -5,7 +5,7 @@ import MiduLogoIcon from '@/icons/MiduLogo.svg'
 ---
 
 <footer>
-  <Container class="pb-0 pt-12 px-section">
+  <Container class="pb-0 pt-12">
     <div
       class="flex md:flex-row flex-col max-md:gap-y-4 justify-between items-center border-b border-white/10 pb-2"
     >

--- a/src/sections/PreEvent.astro
+++ b/src/sections/PreEvent.astro
@@ -7,12 +7,12 @@ import InfojobsLogo from '@/icons/InfojobsLogo.svg'
 import { Image } from 'astro:assets'
 ---
 
-<section class="bg-javascript-radial text-black flex flex-col px-0">
-  <Container class="py-0 xl:py-12">
-    <div class="pt-6 xl:pt-12 pb-4 px-6">
-      <div class="flex flex-col xl:flex-row gap-6 xl:gap-0">
-        <div class="flex flex-col flex-1 gap-4 font-clash pt-6">
-          <h3 class="text-4xl xl:text-7xl font-medium text-balance">
+<Container class="xl:py-12 xl:pb-40">
+<section class="bg-javascript-radial text-black flex flex-col">
+    <div class="py-6 px-6">
+      <div class="flex flex-col xl:flex-row gap-6 xl:gap-6">
+        <div class="flex flex-col flex-1 gap-4 xl:px-[18px] font-clash pt-6">
+          <h3 class="text-4xl sm:text-5xl 2xl:text-6xl font-medium text-pretty sm:max-w-[480px] 2xl:max-w-[600px]">
             Únete al Pre-Evento en Barcelona
           </h3>
           <p class="text-lg xl:text-2xl font-medium">
@@ -32,16 +32,16 @@ import { Image } from 'astro:assets'
               <PointerMap class="w-6 h-6 inline-block mr-2" />
               Oficinas de InfoJobs, Barcelona.
             </p>
-            <p class="xl:text-lg flex items-center">
+            <p class="xl:text-base 2xl:text-lg flex items-center">
               <Ticket class="w-6 h-6 inline-block mr-2" />
-              <span class="text-light-gray flex flex-col xl:flex-row xl:gap-1">
-                <strong class="font-medium text-white">¡Es Gratis!</strong>
+              <span class="text-light-gray flex flex-col sm:flex-row sm:gap-1">
+                <strong class="font-medium text-white min-w-fit">¡Es Gratis!</strong>
                 Prioridad para asistentes confirmados de la JSConf.
               </span>
             </p>
           </div>
         </div>
-        <div class="w-full xl:w-[43%] flex items-end justify-end xl:px-0">
+        <div class="w-full xl:w-[43%] flex items-end justify-end ">
           <Image
             width={512}
             height={484}
@@ -51,12 +51,12 @@ import { Image } from 'astro:assets'
           />
         </div>
       </div>
-      <div class="w-full justify-center flex xl:justify-start pt-4 px-6">
-        <p class="text-sm xl:p-0 font-medium">
-          <InfojobsLogo class="h-10 inline-block" />
+      <div class="w-full justify-center flex xl:justify-start pt-4 xl:px-4 xl:pt-6">
+        <p class="text-sm sm:text-base font-medium text-center">
+          <InfojobsLogo class="inline-block" />
           ¡Patrocinador oficial del Pre-Evento!
         </p>
       </div>
     </div>
+  </section>
   </Container>
-</section>

--- a/src/sections/Presenter.astro
+++ b/src/sections/Presenter.astro
@@ -30,8 +30,8 @@ const socialNetworks = [
 ]
 ---
 
-<section class="bg-black text-white mx-auto px-4 py-12">
-  <Container class="lg:p-24">
+<section class="bg-black text-white mx-auto py-12">
+  <Container>
     <div class="flex md:flex-row flex-col-reverse lg:gap-x-20 gap-x-10">
       <Image
         width={520}

--- a/src/sections/Speakers.astro
+++ b/src/sections/Speakers.astro
@@ -105,13 +105,16 @@ const speakers = [
         la comunidad hispana!
       </h2>
     </div>
-    <div class="grid lg:grid-cols-4 grid-cols-2 md:gap-x-6 gap-x-3 md:gap-y-10 gap-y-6 pt-20">
+    <div class="grid xl:grid-cols-4 lg:grid-cols-3 grid-cols-2 md:gap-x-6 gap-x-3 md:gap-y-10 gap-y-6 pt-20">
       {
         speakers.map((speaker, index) => (
           <Card
             {...speaker}
             companyLogo={speaker.companyLogo}
-            marginTop={`${(index % 4) * 20}px`}
+            marginTop={{
+              xl: `${(index % 4) * 20}px`,
+              lg: `${(index % 3) * 20}px`,
+            }}
           />
         ))
       }

--- a/src/sections/Why.astro
+++ b/src/sections/Why.astro
@@ -13,7 +13,7 @@ import LinkEntrada from '@/components/LinkEntrada.astro'
       height="1123"
       viewBox="0 0 770 1123"
       fill="none"
-      class="hidden md:block"
+      class="hidden lg:block"
       xmlns="http://www.w3.org/2000/svg"
     >
       <path
@@ -45,7 +45,7 @@ import LinkEntrada from '@/components/LinkEntrada.astro'
       ¿Por qué no debes perderte la JSConf?
     </h2>
 
-    <div class="flex pt-6 pb-12 gap-x-6 justify-around flex-col md:flex-row gap-y-8">
+    <div class="flex pt-6 pb-12 gap-x-6 justify-around flex-col xl:flex-row gap-y-8">
       <WhyCard>
         <h3 slot="title" class="font-clash md:text-4xl text-2xl font-[450]">
           Contacto directo con los <strong class="text-javascript font-[450]"

--- a/src/sections/Workshops.astro
+++ b/src/sections/Workshops.astro
@@ -68,7 +68,7 @@ const workshops: Workshop[] = [
   />
   <Container>
     <div class="flex justify-center flex-wrap">
-      <h2 class="font-clash text-white text-[clamp(2rem,5vw,4.5rem)] text-center leading-tight">
+      <h2 class="font-clash text-white text-[clamp(2rem,5vw,4.5rem)] text-center leading-tight text-balance">
         No solo aprendizaje, también conexión,
         <CrossContainerTitle>workshops del evento</CrossContainerTitle>
       </h2>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -4,6 +4,14 @@ import prose from '@tailwindcss/typography'
 export default {
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
+    container: {
+      center: true,
+      screens: {
+        lg: '765px',
+        xl: '1024px',
+        '2xl': '1424px',
+      },
+    },
     extend: {
       colors: {
         javascript: '#f7df1e',


### PR DESCRIPTION
- Extendí la config de tailwind para agregar una clase "container" que le da un max-w a las secciones que lo utilizan en el figma.

![Screenshot 2024-12-21 155029](https://github.com/user-attachments/assets/335cee44-17f2-4b15-b965-92ae36f5f51e)


- Corregí el gradiente en el titulo principal

![Screenshot 2024-12-21 160319](https://github.com/user-attachments/assets/dc123479-5b57-4d4f-8a95-246eee9b39e2)

- La seccion Why tenía un scroll horizontal y no entraba bien en ciertos tamaños de pantalla

![Screenshot 2024-12-21 160241](https://github.com/user-attachments/assets/96a3832d-bff8-4791-947b-e56cf3a65561)


- Los Speakers no entraban bien en 1024px, bajé el grid a 3 y modifiqué el marginTop para que tenga distintos comportamientos en lg y en xl. 

![Screenshot 2024-12-21 161539](https://github.com/user-attachments/assets/aa90fc72-41f2-4cd8-9490-a12d3d0c015a)


- Corregí el titulo de Workshops.astro, con un text-balance y el ancho del texto "Programa del evento" para que quede como en el figma.

![Screenshot 2024-12-21 161750](https://github.com/user-attachments/assets/c950e88f-c456-46e2-af08-76f80ce4d641)

