### PR TITLE
fix: min-width in speakers section

### DIFF
--- a/src/components/SpeakerCard.astro
+++ b/src/components/SpeakerCard.astro
@@ -150,7 +150,7 @@ const {
     }
   }
 
-  @media (max-width: 1280px) {
+  @media (min-width: 1024px) and (max-width: 1280px) {
     .card {
       margin-top: var(--marginTopLg);
     }


### PR DESCRIPTION
En la feature olvidé indicar el min-width y estaba afectando tamaños menores a LG. 
Corregido y testeado

![Screenshot 2024-12-22 122714](https://github.com/user-attachments/assets/3ff2bc0b-91ff-4e52-8c4d-36c508125e2f)
