### PR TITLE
feat: enable user-select for speaker cards

### DIFF
--- a/src/components/SpeakerCard.astro
+++ b/src/components/SpeakerCard.astro
@@ -42,7 +42,7 @@ const {
     </figcaption>
   </figure>
   <div
-    class="flex flex-col flex-1 md:gap-y-[14px] gap-y-[6px] bg-white/5 border border-white/10 md:p-6 p-3"
+    class="flex flex-col flex-1 md:gap-y-[14px] gap-y-[6px] bg-white/5 border border-white/10 md:p-6 p-3 select-text"
   >
     <div>
       <div class="flex flex-row items-center justify-between">


### PR DESCRIPTION
Este PR habilita la selección de texto (`user-select: text`) en las tarjetas de los speakers (`src/components/SpeakerCard.astro`), permitiendo a los usuarios copiar información como nombres fácilmente. Este cambio mejora la experiencia de usuario al hacer más funcional y accesible la interacción con la información mostrada.

### Detalles del cambio:
- Modificación en `src/components/SpeakerCard.astro` para incluir la propiedad `user-select: text`.

![enable-user-select-in-speaker-card](https://github.com/user-attachments/assets/33577c1e-42ae-41f0-8e10-61b0a9d3a2ff)

