### PR TITLE
fix: "exclusiva" in hero subtitle

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -19,10 +19,9 @@ import { Image } from 'astro:assets'
     <div class="text-[clamp(1.8rem,5vw,4.5rem)] leading-[100%] font-light space-y-2">
       <p>
         Una experiencia <span
-          class="text-black relative before:content-[''] overflow-hidden before:absolute before:w-full before:h-full before:bg-gradient-to-r before:from-[#FFFE65] before:to-[#F7DF1F] before:rotate-2 mix-blend-lighten before:-z-30 before:-left-2 before:top-0"
-        >
-          exclusiva
-        </span> de
+          class="text-black relative before:content-[''] overflow-hidden before:absolute before:w-[calc(100%_+_0.25em)] before:h-full before:bg-gradient-to-r before:from-[#FFFE65] before:to-[#F7DF1F] before:rotate-2 mix-blend-lighten before:-z-30 before:-left-[0.125em] before:top-0"
+          >exclusiva</span
+        > de
       </p>
       <p>JavaScript</p>
     </div>


### PR DESCRIPTION
Esta PR endereza el enmarcado "exclusiva" para móviles:

| Antes | Después |
|---|---|
| ![Screenshot_20241229-172807](https://github.com/user-attachments/assets/35885e2d-9d93-45f5-8ac8-42b3b0c94a48) | ![Screenshot_20241229-172834](https://github.com/user-attachments/assets/e638d7dd-32fa-41b6-b24c-a1d2701fc8cf) |
