### PR TITLE
fix: header brand in mobile

### DIFF
--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -18,17 +18,17 @@ const sections = [
   class="py-6 z-[999] fixed top-0 left-0 right-0 bg-transparent transition-colors duration-300 px-section"
 >
   <div class="flex gap-4 justify-between items-center max-w-[90rem] mx-auto">
-    <div class="flex flex-row gap-x-3 md:items-center items-start justify-center">
-      <LogoIcon class="md:size-16 size-9" />
-      <div>
+    <div class="flex gap-x-3 items-center">
+      <LogoIcon class="md:size-16 size-10" />
+      <div class="max-md:-mb-1">
         <h3
           class="font-clash font-semibold max-md:h-4 md:text-2xl text-lg flex flex-row items-center gap-x-2 text-white"
         >
           JSConf España
           <span
-            class="rounded-full bg-javascript text-black font-semibold md:text-lg text-xs md:px-3 px-2 leading-none flex justify-center items-center"
-            >2025
-          </span>
+            class="rounded-full bg-javascript text-black font-semibold md:text-lg text-xs md:px-3 md:py-1 px-2 py-0.5 !leading-none flex justify-center items-center"
+            >2025</span
+          >
         </h3>
         <span class="uppercase font-light opacity-80 text-sm text-white max-md:text-xs"
           >1 MARZO 2025</span


### PR DESCRIPTION
Esta PR corrige los márgenes del **brand** para móviles:

| Antes | Después |
|---|---|
| ![Screenshot_20241229-173059](https://github.com/user-attachments/assets/b599a1c3-21db-453e-bca6-96dab86f5d02) | ![Screenshot_20241229-173137](https://github.com/user-attachments/assets/976efc27-0004-4020-a55b-01fbe215cbff) |
