### PR TITLE
fix: readability for mobile in speakers section

### DIFF
--- a/src/components/SpeakerCard.astro
+++ b/src/components/SpeakerCard.astro
@@ -47,7 +47,7 @@ const Tag = social ? 'a' : 'div'
         class="w-full aspect-square object-cover"
       />
       <figcaption>
-        <p class="gap-x-1 md:text-base text-[10px] text-yellow-400 font-medium">
+        <p class="gap-x-1 text-yellow-400 font-medium">
           {role}
         </p>
       </figcaption>
@@ -57,21 +57,21 @@ const Tag = social ? 'a' : 'div'
     >
       <div>
         <div class="flex flex-row items-center justify-between">
-          <h3 class="md:text-2xl text-xs font-medium">{name}</h3>
+          <h3 class="text-2xl font-medium">{name}</h3>
           {
             typeof Logo === 'string' ? (
-              <Image width={24} height={24} src={Logo} alt={company} class="md:size-6 size-3" />
+              <Image width={24} height={24} src={Logo} alt={company} class="size-6" />
             ) : typeof Logo !== 'undefined' ? (
-              <Logo class="md:size-6 size-3" />
+              <Logo class="size-6" />
             ) : null
           }
         </div>
-        <div class="flex flex-row gap-x-1 md:text-base text-[10px] text-yellow-400 font-medium">
+        <div class="flex flex-row gap-x-1 text-yellow-400 font-medium">
           <p>{role}</p>
           {company && <p>@{company}</p>}
         </div>
       </div>
-      <p class="md:text-base text-xs sm:text-sm text-neutral-300 md:min-h-16">{description}</p>
+      <p class="text-neutral-300 md:min-h-16">{description}</p>
     </div>
   </article>
 </Tag>

--- a/src/sections/Speakers.astro
+++ b/src/sections/Speakers.astro
@@ -115,7 +115,7 @@ const speakers = [
       </h2>
     </div>
     <div
-      class="grid xl:grid-cols-4 lg:grid-cols-3 grid-cols-2 md:gap-x-6 gap-x-3 md:gap-y-10 gap-y-6 pt-20"
+      class="grid xl:grid-cols-4 lg:grid-cols-3 sm:grid-cols-2 grid-cols-1 md:gap-x-6 gap-x-3 md:gap-y-10 gap-y-6 pt-20"
     >
       {
         speakers.map((speaker, index) => (


### PR DESCRIPTION
Esta PR deja las tarjetas de los **speakers** en **una sola columna para móviles** hasta `sm` en Tailwind.

Esto hace mejorar la legibilidad en los títulos y las descripciones.

| Antes | Después |
|---|---|
| ![Screenshot_20241229-172907](https://github.com/user-attachments/assets/1f2d033b-fc6e-40ee-a217-a0dbef084bbb) | ![Screenshot_20241229-173022](https://github.com/user-attachments/assets/ee9a70c1-dbea-491d-915a-fc421bf4baf4) |
