### PR TITLE
fix: footer brand in mobile

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -9,19 +9,21 @@ import MiduLogoIcon from '@/icons/MiduLogo.svg'
     <div
       class="flex md:flex-row flex-col max-md:gap-y-4 justify-between items-center border-b border-white/10 pb-2"
     >
-      <div class="flex flex-row gap-x-3 md:items-center items-start justify-center">
-        <LogoIcon class="md:size-16 size-9" />
-        <div>
+      <div class="flex gap-x-3 items-center justify-center">
+        <LogoIcon class="md:size-16 size-10" />
+        <div class="max-md:-mb-1">
           <h4
             class="font-clash font-semibold max-md:h-4 md:text-2xl text-lg flex flex-row items-center gap-x-2 text-white"
           >
             JSConf España
             <span
-              class="rounded-full bg-javascript text-black font-semibold md:text-lg text-xs md:px-3 px-2 leading-none flex justify-center items-center"
-              >2025
-            </span>
+              class="rounded-full bg-javascript text-black font-semibold md:text-lg text-xs md:px-3 md:py-1 px-2 py-0.5 !leading-none flex justify-center items-center"
+              >2025</span
+            >
           </h4>
-          <span class="uppercase font-light text-white max-md:text-xs">1 MARZO 2025</span>
+          <span class="uppercase font-light opacity-80 text-sm text-white max-md:text-xs"
+            >1 MARZO 2025</span
+          >
         </div>
       </div>
 


### PR DESCRIPTION
Esta PR corrige los márgenes del **brand** en el **footer** para móviles:

| Antes | Después |
|---|---|
| ![Screenshot_20241229-204921](https://github.com/user-attachments/assets/0a14eafa-0261-4839-93ee-9687a36e2e5f) | ![Screenshot_20241229-204941](https://github.com/user-attachments/assets/2fd63719-6872-4464-9eb7-befa8c2b8a9d) |
