### PR TITLE
fix: enhance sponsor section layout and accessibility

### DIFF
--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -25,7 +25,7 @@ const icons: Record<string, any> = {
     </div>
 
     <a
-      class="group bg-black border border-black hover:bg-white transition py-6 px-12 mb-12 flex items-center justify-between flex-col md:flex-row w-full"
+      class="group bg-black border border-black hover:bg-white transition py-6 px-12 mb-12 flex items-center justify-between flex-col lg:flex-row w-full gap-6 lg:gap-12"
       href="https://midu.link/keepcoding"
       target="_blank"
       rel="noopener noreferrer"
@@ -35,10 +35,11 @@ const icons: Record<string, any> = {
         height={96}
         src="/sponsors/keepcoding.webp"
         alt="sponsor top"
-        class="h-24 object-contain group-hover:scale-105 transition"
+        class="h-24 object-contain group-hover:scale-105 transitiona-all duration-300"
+        aria-label="Visita KeepCoding para ver los mejores bootcamps online"
       />
-      <div>
-        <p class="absolute group-hover:opacity-0 text-white text-xl text-balance">
+      <div class="text-center lg:text-left">
+        <p class="absolute group-hover:opacity-0 text-white text-xl text-balance whitespace-nowrap">
           ¡Los mejores bootcamp online!
         </p>
         <p class="group-hover:opacity-1 text-black text-xl text-balance">


### PR DESCRIPTION
## Cambios realizados
- Cambia el breakpoint de `md` a `lg` para mejorar el layout en pantallas medianas.
- Añade `gap-6 lg:gap-12` para mejorar el espacio entre la imagen y el texto.
- Añade `whitespace-nowrap` para evitar el rompimiento de línea en el texto.
- Añade `aria-label` para mejorar la accesibilidad.

## Sugerencia adicional
Durante la revisión del componente, noté que el degradado del logo de KeepCoding genera un contraste negativo cuando el fondo cambia a blanco durante el hover. Esto puede afectar la legibilidad y la experiencia de usuario.

Sugiero evaluar la posibilidad de ajustar el color del texto o el degradado del logo para mejorar el contraste en este estado. No incluí este cambio en mi rama porque desconozco si es viable modificar el logo de KeepCoding, pero estaría encantado de implementarlo si se considera apropiado.

## Contexto
El componente de sponsor KeepCoding tenía problemas de layout en resoluciones cercanas al breakpoint, y el texto se rompía en varias líneas. Estos cambios mejoran la experiencia de usuario y la accesibilidad.

## Screenshots
### Estado antes de los cambios:
![Estado antes de los cambios](https://github.com/user-attachments/assets/8ef1a33e-c663-490a-a7f1-bf9e1e77b6b9)

### Estado después de los cambios:
![Estado después de los cambios](https://github.com/user-attachments/assets/a8db6dbc-b0b5-4a91-b23a-17b617e88e60)