### PR TITLE
geekhadev - refactor: standardizing spacing in WhenAndWhere and Why components

### DIFF
--- a/src/sections/WhenAndWhere.astro
+++ b/src/sections/WhenAndWhere.astro
@@ -16,7 +16,7 @@ import LinkEntrada from '@/components/LinkEntrada.astro'
       </strong>
     </h2>
 
-    <div class="flex py-12 gap-x-10 justify-between flex-col md:flex-row gap-y-8">
+    <div class="flex py-12 gap-x-10 justify-between flex-col md:flex-row gap-y-12">
       <article class="md:p-12 border border-black w-full p-8">
         <span class="flex justify-start gap-x-2 items-center text-xl opacity-70"
           ><Agenda slot="icon-left" />

--- a/src/sections/Why.astro
+++ b/src/sections/Why.astro
@@ -45,7 +45,7 @@ import LinkEntrada from '@/components/LinkEntrada.astro'
       ¿Por qué no debes perderte la JSConf?
     </h2>
 
-    <div id="cards" class="flex pt-6 pb-12 gap-x-6 justify-around flex-col xl:flex-row gap-y-8">
+    <div id="cards" class="flex pt-6 pb-12 gap-x-6 justify-around flex-col xl:flex-row gap-y-6">
       <WhyCard>
         <h3 slot="title" class="font-clash md:text-4xl text-2xl font-[450]">
           Contacto directo con los <strong class="text-javascript font-[450]"


### PR DESCRIPTION
Standardizing spacing in WhenAndWhere component elements

Previous:
![Screenshot 2025-01-06 at 11 04 42 AM](https://github.com/user-attachments/assets/69e59dd7-a75a-41be-93a3-424c5fb38286)

Current:
![Screenshot 2025-01-06 at 11 04 53 AM](https://github.com/user-attachments/assets/f3605572-6625-4aec-9e4f-7580673dbfec)

Nota: es un pequeño cambio pero para mantener los espaciados estandares.