### PR TITLE
Cambio estilos en componentes InfoTag y WhenAndWhere

### DIFF
--- a/src/components/InfoTag.astro
+++ b/src/components/InfoTag.astro
@@ -7,7 +7,7 @@ const { text } = Astro.props
 ---
 
 <span
-  class="flex flex-row gap-x-2 items-center font-clash font-medium justify-center w-fit bg-neutral-100 px-6 py-3"
+  class="flex flex-row gap-x-4 items-center font-clash font-medium justify-start w-full bg-neutral-100 px-6 py-3"
 >
   <slot />
   {text}

--- a/src/sections/WhenAndWhere.astro
+++ b/src/sections/WhenAndWhere.astro
@@ -9,7 +9,7 @@ import LinkEntrada from '@/components/LinkEntrada.astro'
 ---
 
 <section class="bg-javascript text-black pb-8 py-12 px-6">
-  <Container>
+  <Container class="px-0">
     <h2 class="text-6xl text-center font-clash max-w-5xl mx-auto">
       El día que Madrid se convertirá en la <strong class="font-semibold"
         >capital española de <UnderlineWord class="!left-20">JavaScript</UnderlineWord>

--- a/src/sections/WhenAndWhere.astro
+++ b/src/sections/WhenAndWhere.astro
@@ -9,9 +9,9 @@ import LinkEntrada from '@/components/LinkEntrada.astro'
 ---
 
 <section class="bg-javascript text-black pb-8 py-12 px-6">
-  <Container class="px-0">
+  <Container>
     <h2 class="text-6xl text-center font-clash max-w-5xl mx-auto">
-      El día que Madrid se convertirá en la <strong class="font-semibold"
+      El día que Madrid se convertirá en la <strong class="font-medium"
         >capital española de <UnderlineWord class="!left-20">JavaScript</UnderlineWord>
       </strong>
     </h2>


### PR DESCRIPTION
InfoTag
Cambio tags a w100%, y así no se verán de diferentes tamaños o escalonados
Antes
![image](https://github.com/user-attachments/assets/0095c724-b91b-476a-9feb-dcee8e9550de)
Despues
![image](https://github.com/user-attachments/assets/7eeacc69-d1d5-4037-a620-119e338adeb6)

WhenAndWhere
Bajo un poco el weight, así en mobile el texto no se sobresale, se veía un poco descentrado por eso
Antes
![image](https://github.com/user-attachments/assets/ebfa7ccc-49d3-4045-8a3d-f7313f93fa40)
Después
![image](https://github.com/user-attachments/assets/0efe314e-a579-41d1-8267-3d1a079a227b)
