### PR TITLE
fix: minor detail in #home link href to include slash for a correct navigation

### DIFF
--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -20,7 +20,7 @@ const sections = [
   class="py-6 z-[999] fixed top-0 left-0 right-0 bg-transparent transition-colors duration-300 px-section"
 >
   <div class="flex gap-4 justify-between items-center max-w-[90rem] mx-auto">
-    <a href="#home" class="flex gap-x-3 items-center" aria-label="Ir al inicio">
+    <a href="/#home" class="flex gap-x-3 items-center" aria-label="Ir al inicio">
       <LogoIcon class="md:size-16 size-10" />
       <div class="max-md:-mb-1">
         <h3


### PR DESCRIPTION
Just a minor detail I noticed while browsing the site :)

`Before:`
<img width="340" height="51" alt="Captura de pantalla 2025-12-21 a la(s) 11 04 08 p m" src="https://github.com/user-attachments/assets/f5ec6754-b365-46fb-a32e-41ff2ebadaf0" />

`Now:`
<img width="349" height="51" alt="Captura de pantalla 2025-12-21 a la(s) 11 04 59 p m" src="https://github.com/user-attachments/assets/b7da933f-2842-4218-9d10-8aae3452a430" />
