### PR TITLE
style: agregar margen al fragmento para evitar superposición con el logo de infojobs

### DIFF
--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -23,7 +23,7 @@ import infojobsLogo from '@/icons/InfojobsLogo.svg?raw'
           <i class="fas fa-crown text-js-yellow mr-1"></i> Principal Sponsor
         </span>
 
-        <div class="w-full max-w-[400px] mb-4 mt-4">
+        <div class="w-full max-w-[400px] mb-4 mt-4 md:mt-0">
           <Fragment set:html={infojobsLogo} />
         </div>
         <p class="text-xs md:text-sm uppercase font-light text-js-yellow/90 tracking-wider">


### PR DESCRIPTION
Se agrega margen al fragmento en mobile para evitar que el contenido quede pegado al logo de InfoJobs. , un cambio muy simple pero efectivo!
