### PR TITLE
fix: update Ignia Cloud sponsor URL

### DIFF
--- a/src/data/sponsors.json
+++ b/src/data/sponsors.json
@@ -19,7 +19,7 @@
       {
         "name": "Ignia Cloud",
         "image": "/sponsors/ignia-cloud.webp",
-        "url": "https://igniacloud.com/",
+        "url": "https://www.ignia.cloud/",
         "description": "Soluciones en la Nube Seguras, Escalables y de Alto Rendimiento"
       },
       {


### PR DESCRIPTION
Se ha corregido la URL del patrocinador Ignia Cloud de \https://igniacloud.com/\ a \https://www.ignia.cloud/\ ya que la anterior no era correcta.